### PR TITLE
Fix: JSDoc dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-import-resolver-typescript": "^2.5.0",
     "eslint-plugin-import": "^2.25.3",
+    "eslint-plugin-jsdoc": "^37.4.0",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.27.1",
     "eslint-plugin-react-hooks": "^4.3.0",
@@ -55,7 +56,6 @@
   "devDependencies": {
     "@marcbouchenoire/prettier-config": "^1.1.0",
     "eslint": "^8.4.0",
-    "eslint-plugin-jsdoc": "^37.2.2",
     "husky": "4.3.8",
     "lint-staged": "^12.1.2",
     "np": "^7.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1257,10 +1257,10 @@ eslint-plugin-import@^2.25.3:
     resolve "^1.20.0"
     tsconfig-paths "^3.11.0"
 
-eslint-plugin-jsdoc@^37.2.2:
-  version "37.2.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.2.2.tgz#70b487f281ec2d8b25bf5a0a739cf3e708e393fc"
-  integrity sha512-ChNYa4JBfEgyx7Fuy3obZM0w1jxd1DFdkMDk9QVrLfdZubtXCVK5Lvx+GKExeCxKLU33wLnOOBoImUL2/16JWQ==
+eslint-plugin-jsdoc@^37.4.0:
+  version "37.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.4.0.tgz#6e6eade5494150a392365f63bbd2fb88caeb8d0c"
+  integrity sha512-XWKMMHFq7eUdC8XMzuQSskevJvlHTDSAJm/2qtEZ7+qhZTZ0YjeqWaUn7KGdrmxLNqtWwtJ67LdIPgrYUZ5EoA==
   dependencies:
     "@es-joy/jsdoccomment" "0.13.0"
     comment-parser "1.3.0"


### PR DESCRIPTION
This PR fixes [`eslint-plugin-jsdoc`](https://github.com/gajus/eslint-plugin-jsdoc) being added to `devDependencies` instead of `dependencies`.